### PR TITLE
Update old babel to a new @babel/eslint-parser

### DIFF
--- a/react-web/.eslintrc.js
+++ b/react-web/.eslintrc.js
@@ -7,7 +7,7 @@ module.exports = {
         node: true // Defines things like process.env when generating through node
     },
     extends: [],
-    parser: "babel-eslint", // Uses babel-eslint transforms.
+    parser: "@babel/eslint-parser", // Uses babel-eslint transforms.
     parserOptions: {
         ecmaFeatures: {
             jsx: true

--- a/react-web/package-lock.json
+++ b/react-web/package-lock.json
@@ -19,7 +19,9 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@babel/eslint-parser": "^7.19.1",
         "babel-eslint": "^10.1.0",
+        "eslint": "^8.35.0",
         "tailwindcss": "^3.2.7"
       }
     },

--- a/react-web/package.json
+++ b/react-web/package.json
@@ -32,7 +32,9 @@
     ]
   },
   "devDependencies": {
+    "@babel/eslint-parser": "^7.19.1",
     "babel-eslint": "^10.1.0",
+    "eslint": "^8.35.0",
     "tailwindcss": "^3.2.7"
   }
 }


### PR DESCRIPTION
The project used to use the deprecated version of babel parser, I removed it and added the new one and it works now without throwing any errors and also build is possible to run.