### PR TITLE
Hotfix to ensure code is highlighted correctly

### DIFF
--- a/react-web/src/api/api.js
+++ b/react-web/src/api/api.js
@@ -12,10 +12,11 @@ export default async function onSubmit(apiKey, inputText, setResult) {
 
     const completion = await openai.createChatCompletion({
       model: "gpt-3.5-turbo",
-      messages: [{role: "user", content: inputText}],
+      messages: [{role: "user", content: inputText + " if code then respond with ```language at start of codeblock"}],
     });
 
     const txt = completion.data.choices[0].message.content;
+    // console.log(txt);
     setResult(txt.trimStart());
   } catch(error) {
     console.error(error);

--- a/react-web/src/components/Codeblock.js
+++ b/react-web/src/components/Codeblock.js
@@ -11,17 +11,17 @@ export default function Codeblock(props) {
 
   const handleClick = () => {
     setCopied(true);
-    console.log(copied);
+  
     navigator.clipboard.writeText(props.children);
     setTimeout(() => {
       setCopied(false);
-      console.log(copied);
     }, 3000);
   }
 
   return (
     <pre>
         <div className='flex justify-between text-sm py-1 px-4 -m-4 mb-4 bg-gray-700 text-gray-300 rounded-sm'>
+          {/* {console.log(props.language)} */}
           <div>{props.language}</div>
           <button onClick={handleClick}>{copied ? 'Copied' : 'Copy'}</button>
         </div>


### PR DESCRIPTION
This is fix for #22 that should ensure that gpt model (always) return with language specified like:  \`\`\`language

It's fixed in such a way, that there is an addition to the text prompt that says 
```js
+ " if code then respond with ```language at start of codeblock"
```

It for sure requires a lot more testing, but it's enough for now.